### PR TITLE
Fix dwell phrase selection not speaking aloud

### DIFF
--- a/iosApp/iosApp/Game/GameOverlayView.swift
+++ b/iosApp/iosApp/Game/GameOverlayView.swift
@@ -170,8 +170,8 @@ private struct GameGazeZoneRegistrar: View {
             .onChange(of: dwellManager.hoveredButtonId) { _, hovered in
                 coordinator.showExitControl = hovered == id
             }
-            .onChange(of: dwellManager.activationToken) { _, _ in
-                guard dwellManager.activatedButtonId == id else { return }
+            .onChange(of: dwellManager.lastActivation) { _, activation in
+                guard let activation, activation.buttonId == id else { return }
                 coordinator.stopEarly()
             }
             .onDisappear {

--- a/iosApp/iosApp/Media/MediaPlaybackOverlayView.swift
+++ b/iosApp/iosApp/Media/MediaPlaybackOverlayView.swift
@@ -246,8 +246,8 @@ private struct MediaGazeZoneRegistrar: View {
                     coordinator.showExitControl = hovered == id
                 }
             }
-            .onChange(of: dwellManager.activationToken) { _, _ in
-                guard dwellManager.activatedButtonId == id else { return }
+            .onChange(of: dwellManager.lastActivation) { _, activation in
+                guard let activation, activation.buttonId == id else { return }
                 switch controlKind {
                 case .center:
                     coordinator.togglePlayPause()

--- a/iosApp/iosApp/Tracking/DwellSelectionManager.swift
+++ b/iosApp/iosApp/Tracking/DwellSelectionManager.swift
@@ -15,8 +15,16 @@ enum GazeCoordinateSpace {
 /// 1. Register button frames via `registerButton(id:frame:)`
 /// 2. Feed gaze positions via `updateGazePosition(_:)`
 /// 3. Observe `hoveredButtonId` and `dwellProgress` for UI
-/// 4. Listen to `activatedButtonId` for selection events
+/// 4. Listen to `lastActivation` / `activationToken` for selection events
 /// 5. Call `activateHoveredButton()` for instant switch-based selection
+///
+/// One dwell/switch activation event (token + button id published together).
+struct DwellActivation: Equatable {
+    let token: UInt64
+    let buttonId: String
+}
+
+/// Manages dwell-based selection for gaze, switch, and scanning input.
 class DwellSelectionManager: ObservableObject {
     /// The button currently being hovered over (nil if none)
     @Published var hoveredButtonId: String?
@@ -33,6 +41,10 @@ class DwellSelectionManager: ObservableObject {
     /// Increments on every activation so observers reliably receive events even when
     /// `activatedButtonId` repeats or LazyVGrid/TabView recycles child views.
     @Published private(set) var activationToken: UInt64 = 0
+
+    /// Atomic activation snapshot so observers never race `activatedButtonId`
+    /// being cleared by a subsequent `startDwell` before they handle the event.
+    @Published private(set) var lastActivation: DwellActivation?
 
     /// The button highlighted in scanning mode (nil if not scanning)
     @Published var scanHighlightedButtonId: String?
@@ -263,9 +275,13 @@ class DwellSelectionManager: ObservableObject {
 
     /// Record an activation and notify observers (haptic optional).
     private func publishActivation(buttonId: String, hapticStyle: UIImpactFeedbackGenerator.FeedbackStyle?) {
-        DebugLog.debug("Dwell: activated \(buttonId)", tag: "Dwell")
-        activatedButtonId = buttonId
         activationToken &+= 1
+        let activation = DwellActivation(token: activationToken, buttonId: buttonId)
+        DebugLog.debug("Dwell: activated \(buttonId) (token=\(activation.token))", tag: "Dwell")
+        // Keep legacy fields for existing observers, then publish the atomic
+        // snapshot last so `$lastActivation` subscribers always see a matching id.
+        activatedButtonId = buttonId
+        lastActivation = activation
         lastActivationTime = CACurrentMediaTime()
 
         if let hapticStyle {
@@ -450,10 +466,9 @@ struct DwellSelectableModifier: ViewModifier {
             )
             .scaleEffect((isHovered || isScanHighlighted) ? 1.03 : 1.0)
             .animation(.easeInOut(duration: 0.15), value: isHovered || isScanHighlighted)
-            .onChange(of: dwellManager.activationToken) { _, _ in
-                if dwellManager.activatedButtonId == id {
-                    onActivate()
-                }
+            .onChange(of: dwellManager.lastActivation) { _, activation in
+                guard let activation, activation.buttonId == id else { return }
+                onActivate()
             }
             .onDisappear {
                 dwellManager.unregisterButton(id: id)

--- a/iosApp/iosApp/Utils/TTSManager.swift
+++ b/iosApp/iosApp/Utils/TTSManager.swift
@@ -18,6 +18,8 @@ class TTSManager: NSObject, ObservableObject, @unchecked Sendable, AVSpeechSynth
     
     private var phraseQueue: [String] = []
     
+    private var utteranceGeneration: UInt64 = 0
+
     private override init() {
         super.init()
         synthesizer.delegate = self
@@ -59,19 +61,35 @@ class TTSManager: NSObject, ObservableObject, @unchecked Sendable, AVSpeechSynth
     
     /// Speak text immediately (interrupts current speech)
     func speak(_ text: String) {
-        guard !text.isEmpty else { return }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
 
-        configureAudioSession()
-        
-        // Stop current speech
-        if synthesizer.isSpeaking {
-            synthesizer.stopSpeaking(at: .immediate)
+        // AVSpeechSynthesizer + AVAudioSession changes must run on the main thread.
+        // Defer one turn so session activation settles before enqueueing speech
+        // (avoids silent no-ops while the camera capture session is active).
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.configureAudioSession()
+
+            self.utteranceGeneration &+= 1
+            let generation = self.utteranceGeneration
+
+            if self.synthesizer.isSpeaking || self.synthesizer.isPaused {
+                self.synthesizer.stopSpeaking(at: .immediate)
+            }
+
+            self.currentText = trimmed
+            let utterance = self.createUtterance(from: trimmed)
+            DebugLog.info("Speaking: \"\(trimmed)\"", tag: "TTSManager")
+
+            // stopSpeaking's didCancel can race an immediate speak(); defer one
+            // turn so the cancelled utterance settles before the new one starts.
+            DispatchQueue.main.async { [weak self] in
+                guard let self, self.utteranceGeneration == generation else { return }
+                self.synthesizer.speak(utterance)
+                self.isSpeaking = true
+            }
         }
-        
-        currentText = text
-        let utterance = createUtterance(from: text)
-        synthesizer.speak(utterance)
-        isSpeaking = true
     }
     
     /// Add text to queue (speaks after current finishes)
@@ -89,6 +107,7 @@ class TTSManager: NSObject, ObservableObject, @unchecked Sendable, AVSpeechSynth
     
     /// Stop speaking immediately
     func stop() {
+        utteranceGeneration &+= 1
         synthesizer.stopSpeaking(at: .immediate)
         phraseQueue.removeAll()
         isSpeaking = false
@@ -136,10 +155,28 @@ class TTSManager: NSObject, ObservableObject, @unchecked Sendable, AVSpeechSynth
     private func configureAudioSession() {
         let session = AVAudioSession.sharedInstance()
         do {
-            try session.setCategory(.playback, mode: .spokenAudio, options: [.duckOthers])
+            // mixWithOthers keeps TTS audible while the eye-tracking camera
+            // capture session owns the shared audio session.
+            // defaultToSpeaker matters on iPhone; harmless on iPad.
+            try session.setCategory(
+                .playback,
+                mode: .spokenAudio,
+                options: [.duckOthers, .mixWithOthers, .defaultToSpeaker]
+            )
             try session.setActive(true, options: [])
         } catch {
             DebugLog.error("Failed to configure audio session: \(error)", tag: "TTSManager")
+            // Fallback without defaultToSpeaker for older route configurations.
+            do {
+                try session.setCategory(
+                    .playback,
+                    mode: .spokenAudio,
+                    options: [.duckOthers, .mixWithOthers]
+                )
+                try session.setActive(true, options: [])
+            } catch {
+                DebugLog.error("Audio session fallback failed: \(error)", tag: "TTSManager")
+            }
         }
     }
     
@@ -167,9 +204,12 @@ class TTSManager: NSObject, ObservableObject, @unchecked Sendable, AVSpeechSynth
     
     func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didCancel utterance: AVSpeechUtterance) {
         DispatchQueue.main.async { [weak self] in
-            self?.isSpeaking = false
-            self?.currentText = ""
-            self?.phraseQueue.removeAll()
+            guard let self else { return }
+            // A newer speak() may already be in flight after stopSpeaking.
+            guard !self.synthesizer.isSpeaking else { return }
+            self.isSpeaking = false
+            self.currentText = ""
+            self.phraseQueue.removeAll()
         }
     }
 }

--- a/iosApp/iosApp/Views/Categories/CategoriesView.swift
+++ b/iosApp/iosApp/Views/Categories/CategoriesView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import VocableShared
+import Combine
 
 /// Main categories grid screen
 struct CategoriesView: View {
@@ -8,6 +9,7 @@ struct CategoriesView: View {
     @StateObject private var settings = AppSettings.shared
     @State private var selectedCategory: String?
     @State private var navigateToPhases = false
+    @State private var lastHandledActivationToken: UInt64 = 0
     
     init(database: VocableDatabase = DatabaseManager.shared.db) {
         _viewModel = StateObject(wrappedValue: CategoriesViewModel(database: database))
@@ -44,15 +46,25 @@ struct CategoriesView: View {
             .onAppear {
                 viewModel.loadCategories()
                 gazeManager.dwellManager.unregisterButtons(withPrefix: "phrase_")
+                lastHandledActivationToken = gazeManager.dwellManager.activationToken
             }
             .onDisappear {
-                gazeManager.dwellManager.clearAllButtons()
+                // Only drop category targets. clearAllButtons() here races PhrasesView
+                // registration when NavigationStack pushes the phrases destination.
+                gazeManager.dwellManager.unregisterButtons(withPrefix: "cat_")
             }
             .onReceive(NotificationCenter.default.publisher(for: Notification.Name("CategoriesUpdated"))) { _ in
                 viewModel.loadCategories()
             }
-            .onReceive(gazeManager.dwellManager.$activationToken) { _ in
-                dispatchDwellCategoryActivation()
+            .onReceive(gazeManager.dwellManager.$lastActivation.compactMap { $0 }) { activation in
+                dispatchDwellCategoryActivation(activation)
+            }
+            .onChange(of: navigateToPhases) { _, isShowingPhrases in
+                if isShowingPhrases {
+                    // Phrases screen owns dwell targets; drop category registrations
+                    // so covered category tiles cannot steal activations or remount PhrasesView.
+                    gazeManager.dwellManager.unregisterButtons(withPrefix: "cat_")
+                }
             }
         }
         .background(settings.appBorderColor.ignoresSafeArea())
@@ -89,7 +101,13 @@ struct CategoriesView: View {
                         .dwellSelectable(
                             id: "cat_\(category.id)",
                             manager: gazeManager.dwellManager,
-                            onActivate: {}
+                            isActive: !navigateToPhases,
+                            onActivate: {
+                                if let activation = gazeManager.dwellManager.lastActivation,
+                                   activation.buttonId == "cat_\(category.id)" {
+                                    dispatchDwellCategoryActivation(activation)
+                                }
+                            }
                         )
                     }
                 }
@@ -124,14 +142,16 @@ struct CategoriesView: View {
         }
     }
 
-    private func dispatchDwellCategoryActivation() {
-        guard let buttonId = gazeManager.dwellManager.activatedButtonId,
-              buttonId.hasPrefix("cat_") else { return }
-        let categoryId = String(buttonId.dropFirst("cat_".count))
+    private func dispatchDwellCategoryActivation(_ activation: DwellActivation) {
+        guard activation.token != lastHandledActivationToken else { return }
+        guard !navigateToPhases else { return }
+        guard activation.buttonId.hasPrefix("cat_") else { return }
+        let categoryId = String(activation.buttonId.dropFirst("cat_".count))
         guard viewModel.categories.contains(where: { $0.id == categoryId }) else {
-            DebugLog.warn("Dwell: no category matches \(buttonId)", tag: "Dwell")
+            DebugLog.warn("Dwell: no category matches \(activation.buttonId)", tag: "Dwell")
             return
         }
+        lastHandledActivationToken = activation.token
         selectedCategory = categoryId
         navigateToPhases = true
     }

--- a/iosApp/iosApp/Views/Phrases/PhrasesView.swift
+++ b/iosApp/iosApp/Views/Phrases/PhrasesView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import VocableShared
 import UIKit
+import Combine
 
 /// Phrases grid screen for a category
 struct PhrasesView: View {
@@ -11,8 +12,8 @@ struct PhrasesView: View {
     @EnvironmentObject var gameCoordinator: GamePlaybackCoordinator
     @StateObject private var viewModel: PhrasesViewModel
     @StateObject private var settings = AppSettings.shared
-    @StateObject private var ttsManager = TTSManager.shared
     @State private var currentPage = 0
+    @State private var lastHandledActivationToken: UInt64 = 0
     @Environment(\.dismiss) private var dismiss
     
     init(categoryId: String, database: VocableDatabase = DatabaseManager.shared.db) {
@@ -59,6 +60,8 @@ struct PhrasesView: View {
         .tint(.blue)
         .onAppear {
             gazeManager.dwellManager.unregisterButtons(withPrefix: "cat_")
+            // Don't replay activations that happened before this screen appeared.
+            lastHandledActivationToken = gazeManager.dwellManager.activationToken
         }
         .onDisappear {
             gazeManager.dwellManager.clearAllButtons()
@@ -68,8 +71,8 @@ struct PhrasesView: View {
         .onReceive(NotificationCenter.default.publisher(for: Notification.Name("PhrasesUpdated"))) { _ in
             viewModel.loadPhrases()
         }
-        .onReceive(gazeManager.dwellManager.$activationToken) { _ in
-            dispatchDwellPhraseActivation()
+        .onReceive(gazeManager.dwellManager.$lastActivation.compactMap { $0 }) { activation in
+            dispatchDwellPhraseActivation(activation)
         }
         .onReceive(gazeManager.armRaiseActivation) { side in
             guard settings.selectionMode == "armRaise" else { return }
@@ -204,7 +207,15 @@ struct PhrasesView: View {
                                     id: "phrase_\(phrase.id)",
                                     manager: gazeManager.dwellManager,
                                     isActive: currentPage == page,
-                                    onActivate: {}
+                                    onActivate: {
+                                        // Belt-and-suspenders with $lastActivation:
+                                        // LazyVGrid recycling can drop per-button handlers,
+                                        // but when they fire this shares the token dedupe path.
+                                        if let activation = gazeManager.dwellManager.lastActivation,
+                                           activation.buttonId == "phrase_\(phrase.id)" {
+                                            dispatchDwellPhraseActivation(activation)
+                                        }
+                                    }
                                 )
                         }
                     }
@@ -241,20 +252,26 @@ struct PhrasesView: View {
             )
             return
         }
+        DebugLog.info("Phrase selected — speaking \"\(phrase.text)\"", tag: "Dwell")
         viewModel.markPhraseAsSpoken(phraseId: phrase.id)
-        ttsManager.speak(phrase.text)
+        TTSManager.shared.speak(phrase.text)
         mediaCoordinator.onPhraseSelected(phrase)
         gameCoordinator.onPhraseSelected(phrase)
     }
 
-    private func dispatchDwellPhraseActivation() {
-        guard let buttonId = gazeManager.dwellManager.activatedButtonId,
-              buttonId.hasPrefix("phrase_") else { return }
-        let phraseId = String(buttonId.dropFirst("phrase_".count))
+    private func dispatchDwellPhraseActivation(_ activation: DwellActivation) {
+        guard activation.token != lastHandledActivationToken else { return }
+        guard activation.buttonId.hasPrefix("phrase_") else { return }
+        // Ignore stale activations replayed while phrases are still loading
+        // (onReceive resubscribes and can redeliver CurrentValueSubject values).
+        guard !viewModel.isLoading else { return }
+
+        let phraseId = String(activation.buttonId.dropFirst("phrase_".count))
         guard let phrase = viewModel.phrases.first(where: { $0.id == phraseId }) else {
-            DebugLog.warn("Dwell: no phrase matches \(buttonId)", tag: "Dwell")
+            DebugLog.warn("Dwell: no phrase matches \(activation.buttonId)", tag: "Dwell")
             return
         }
+        lastHandledActivationToken = activation.token
         handlePhraseSelection(phrase)
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Gaze dwell on phrases was activating (progress, haptic) but TTS often produced no speech.

Debug logs showed many `Dwell: activated phrase_*` events and later `Dwell: no phrase matches …`, with no TTS activity.

## Root causes
1. **Activation race** – handlers read `activatedButtonId` after `activationToken` changed; a later `startDwell` could clear the id before speech ran.
2. **Audio session conflict** – TTS used `.playback` without `.mixWithOthers` while the eye-tracking camera session was active, so `AVSpeechSynthesizer` could fail silently.
3. **Stale category targets** – category tiles stayed registered under `PhrasesView`, stealing activations / remounting phrases (matches the `no phrase matches` warning).

## Fixes
- Publish atomic `DwellActivation` (token + button id) and dispatch from that
- Token dedupe on phrase/category handlers; ignore stale activations on appear
- Disable/unregister category dwell targets while phrases are showing
- TTS: `.mixWithOthers` + `.defaultToSpeaker`, deferred speak after session/stop settle, speak logging

## Test plan
- [ ] Enable eye gaze, open a category, dwell on a phrase → haptic **and** spoken phrase
- [ ] Confirm debug log shows `Phrase selected — speaking` and `TTSManager Speaking: …`
- [ ] Tap phrase (touch) still speaks
- [ ] Dwell category → navigates; while on phrases, category tiles do not re-activate underneath
- [ ] Repeat dwell (if enabled) speaks again after delay
- [ ] Media/game phrase overlays still respond to dwell controls
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb417-9bdd-70d9-bc52-e48a22a5e187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb417-9bdd-70d9-bc52-e48a22a5e187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

